### PR TITLE
Support password protected routes

### DIFF
--- a/components/error/unauthorised.vue
+++ b/components/error/unauthorised.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <h1 v-text="$t('title')" />
+    <p v-text="$t('description')" />
+  </div>
+</template>
+
+<i18n>
+{
+  "en": {
+    "title": "Password Protected",
+    "description": "The link you accessed is password protected, please enter the password below."
+  },
+  "fr": {
+    "title": "Protégé par mot de passe",
+    "description": "Le lien auquel vous avez accédé est protégé par mot de passe, veuillez saisir le mot de passe ci-dessous."
+  },
+  "es": {
+    "title": "Contraseña protegida",
+    "description": "El enlace al que accedió está protegido con contraseña, ingrese la contraseña a continuación."
+  }
+}
+</i18n>

--- a/components/error/unauthorised.vue
+++ b/components/error/unauthorised.vue
@@ -1,9 +1,20 @@
 <template>
   <div>
     <h1 v-text="$t('title')" />
-    <p v-text="$t('description')" />
+    <p v-text="$t('description')" class="mb-l" />
+    <route-password />
   </div>
 </template>
+
+<script>
+import routePassword from '@/components/routes/route-password.vue'
+
+export default {
+  components: {
+    routePassword
+  }
+}
+</script>
 
 <i18n>
 {

--- a/components/routes/route-password.vue
+++ b/components/routes/route-password.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <form
+      v-on:submit.prevent="submit"
+      class="box animated shake">
+      <input
+        v-model="password"
+        :placeholder="$t('placeholder')"
+        type="password"
+        required>
+      <button
+        class="no-button"
+        type="submit">
+        <c-icon
+          :title="$t('submitInfo')"
+          icon="chevron-circle-right" />
+      </button>
+    </form>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+import randomiser from '@/services/randomiser.js'
+
+export default {
+  data () {
+    return {
+      password: ''
+    }
+  },
+  methods: {
+    ...mapActions('landing', [
+      'setPassword'
+    ]),
+    submit () {
+      this.setPassword(this.password)
+
+      const uniqueKey = randomiser.generateRandomNumber(1000, 1)
+      this.$router.push(`${this.$route.path}#${uniqueKey}`)
+    }
+  }
+}
+</script>
+
+<style scoped lang="scss">
+  input {
+    background-color: transparent;
+    padding: 20px 30px;
+    border: 0;
+    font-size: 1rem;
+    color: white;
+    outline: 0;
+    width: 100%;
+    flex-grow: 1;
+  }
+
+  button.no-button {
+    background: transparent;
+    border: 0;
+    margin: 0;
+    padding: 0;
+    color: white;
+    cursor: pointer;
+  }
+</style>
+
+<i18n>
+{
+  "en": {
+    "placeholder": "Password...",
+    "submitInfo": "Verify your password"
+  },
+  "fr": {
+    "placeholder": "Mot de passe...",
+    "submitInfo": "Vérifiez votre mot de passe"
+  },
+  "es": {
+    "placeholder": "Contraseña...",
+    "submitInfo": "Verifica tu contraseña"
+  }
+}
+</i18n>

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,17 +1,20 @@
 <template>
   <div class="container animated fadeIn">
     <not-found v-if="error.statusCode === 404" />
-    <server-error v-else />
+    <unauthorised v-if="error.statusCode === 401" />
+    <server-error v-if="error.statusCode === 500" />
   </div>
 </template>
 
 <script>
 import notFound from '@/components/error/not-found.vue'
+import unauthorised from '@/components/error/unauthorised.vue'
 import serverError from '@/components/error/server-error.vue'
 
 export default {
   components: {
     notFound,
+    unauthorised,
     serverError
   },
   props: {

--- a/pages/_id.vue
+++ b/pages/_id.vue
@@ -35,20 +35,22 @@ export default {
     reportsViewer
   },
   computed: {
-    ...mapState('landing', ['routeId'])
+    ...mapState('landing', [
+      'routeId'
+    ])
   },
   async fetch ({ store, route, router, error }) {
     const routeId = route.params.id
     const isValid = await store.dispatch('landing/initialise', routeId)
+      .catch((err) => {
+        error({
+          statusCode: err.response.status
+        })
+      })
 
     if (isValid) {
       await store.dispatch('comments/loadComments', routeId)
       await store.dispatch('reports/loadReports', routeId)
-    } else {
-      error({
-        statusCode: 404,
-        message: 'The server successfully processed the request and is not returning any content.'
-      })
     }
   },
   mounted () {

--- a/services/routes.api.js
+++ b/services/routes.api.js
@@ -4,8 +4,13 @@ import { API_BASE_URI } from '@/services/configuration-service.js'
 const postRoute = ({ routeId, target }) =>
   axios.post(`${API_BASE_URI}/routes`, { routeId, target, password: '' })
 
-const getRoute = routeId =>
-  axios.get(`${API_BASE_URI}/routes/${routeId}`).then(response => response.data)
+const getRoute = (routeId, password) => {
+  const route = (password)
+    ? `/routes/${routeId}?password=${password}`
+    : `/routes/${routeId}`
+
+  return axios.get(`${API_BASE_URI}${route}`).then(response => response.data)
+}
 
 export default {
   postRoute,

--- a/store/landing.js
+++ b/store/landing.js
@@ -3,7 +3,8 @@ import routesApi from '@/services/routes.api.js'
 export const state = () => ({
   displayedPanel: 'target', // target / comments / reports
   routeId: null,
-  target: null
+  target: null,
+  password: null
 })
 
 export const mutations = {
@@ -13,13 +14,17 @@ export const mutations = {
   setRouteData: (state, routeData) => {
     state.routeId = routeData.id
     state.target = routeData.target
+    state.password = null
+  },
+  setPassword: (state, password) => {
+    state.password = password
   }
 }
 
 export const actions = {
-  initialise: async ({ commit }, routeId) => {
+  initialise: async ({ commit, state }, routeId) => {
     commit('showPanel', 'target')
-    const routeData = await routesApi.getRoute(routeId)
+    const routeData = await routesApi.getRoute(routeId, state.password)
 
     if (routeData) {
       commit('setRouteData', routeData)
@@ -33,5 +38,8 @@ export const actions = {
   },
   showPanel: ({ commit }, panel) => {
     commit('showPanel', panel)
+  },
+  setPassword: ({ commit }, password) => {
+    commit('setPassword', password)
   }
 }


### PR DESCRIPTION
**Added**
- When the API returns a 401 to a route request display an authorisation page
- Accept a user password and then retry the GET:/route request
- Store the password in the Store, but clear when used.
- Don't expose any route content when password protected, unless authorised.

![image](https://user-images.githubusercontent.com/10741583/72689195-d81f6480-3b06-11ea-9102-811d31db8e8a.png)
