### PR TITLE
Replace Node 8 with Node 14

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
Checks were failing on Node 8, but we don't use, or have the intention to ever use Node 8. So this PR updates the workflow to use 10, 12 and now 14.