### PR TITLE
Spike 1: Mechanisms to add content to the Homepage

### DIFF
--- a/components/homepage/generator-slide.vue
+++ b/components/homepage/generator-slide.vue
@@ -1,0 +1,40 @@
+<template>
+  <div>
+    <h1
+      v-text="$t('title')" />
+    <p
+      v-text="$t('subtitle')"
+      class="mb" />
+    <p
+      v-text="$t('message')"
+      class="mb-l" />
+
+    <generator />
+    <group-wrapper />
+
+    <tabs>
+      <history-trigger />
+      <learn-more-trigger />
+    </tabs>
+  </div>
+</template>
+
+<i18n>
+{
+  "en": {
+    "title": "Custom URL Shortener",
+    "subtitle": "Create free shorter and safer links you can share.",
+    "message": "Paste your link into the box below to get started."
+  },
+  "fr": {
+    "title": "Commencer",
+    "subtitle": "Créez gratuitement des liens plus courts et plus sûrs que vous pouvez partager.",
+    "message": "Collez votre lien dans la case ci-dessous pour commencer."
+  },
+  "es": {
+    "title": "Empezar",
+    "subtitle": "Cree enlaces gratuitos más cortos y seguros que pueda compartir.",
+    "message": "Pegue su enlace en el cuadro a continuación para comenzar."
+  }
+}
+</i18n>

--- a/components/homepage/learn-more-trigger.vue
+++ b/components/homepage/learn-more-trigger.vue
@@ -4,24 +4,24 @@
     to="history"
     class="tab u-border u-hover a-slideInUp">
     <c-icon
-      icon="history"
+      icon="chevron-down"
       class="mr-s" />
 
     <span
-      v-text="$t('history')" />
+      v-text="$t('learnMore')" />
   </nuxt-link>
 </template>
 
 <i18n>
 {
   "en": {
-    "history": "History"
+    "learnMore": "Learn More"
   },
   "fr": {
-    "history": "Histoire"
+    "learnMore": "Learn More"
   },
   "es": {
-    "history": "Historia"
+    "learnMore": "Learn More"
   }
 }
 </i18n>

--- a/components/shared/slide-wrapper.vue
+++ b/components/shared/slide-wrapper.vue
@@ -1,0 +1,54 @@
+<template>
+  <div
+    @wheel="scrollWheel"
+    class="c-slideWrapper">
+    <slide :slide-number="1" :active-slide="activeSlide">
+      <slot name="one" />
+    </slide>
+
+    <slide :slide-number="2" :active-slide="activeSlide">
+      <slot name="two" />
+    </slide>
+  </div>
+</template>
+
+<script>
+import Debounce from '@/services/debounce.js'
+export default {
+  data () {
+    return {
+      activeSlide: 1,
+      totalSlides: 2
+    }
+  },
+  methods: {
+    scrollWheel: Debounce(function (event) {
+      if (event.deltaY < 0) {
+        this.previousSlide()
+      } else if (event.deltaY > 0) {
+        this.nextSlide()
+      }
+    }, 100),
+
+    nextSlide () {
+      if (this.activeSlide < this.totalSlides) {
+        this.activeSlide++
+      }
+    },
+
+    previousSlide () {
+      if (this.activeSlide > 1) {
+        this.activeSlide--
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.c-slideWrapper {
+  position: relative;
+  overflow: hidden;
+  height: 100vh;
+}
+</style>

--- a/components/shared/slide.vue
+++ b/components/shared/slide.vue
@@ -1,0 +1,43 @@
+<template>
+  <transition name="slide-fade">
+    <section
+      v-show="activeSlide === slideNumber"
+      :class="['c-slide', { 'c-slide--active' : activeSlide === slideNumber }]">
+      <div class="u-flex-grow">
+        <slot />
+      </div>
+    </section>
+  </transition>
+</template>
+
+<script>
+export default {
+  props: {
+    activeSlide: {
+      type: Number,
+      required: true
+    },
+
+    slideNumber: {
+      type: Number,
+      required: true
+    }
+  }
+}
+</script>
+
+<style scoped>
+.c-slide {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+}
+
+.c-slide--active {
+  z-index: 10;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,18 +1,13 @@
 <template>
-  <section>
-    <h1
-      v-text="$t('title')" />
-    <p
-      v-text="$t('subtitle')"
-      class="mb" />
-    <p
-      v-text="$t('message')"
-      class="mb-l" />
+  <slide-wrapper>
+    <template v-slot:one>
+      <generator-slide />
+    </template>
 
-    <generator />
-    <group-wrapper />
-    <history-trigger />
-  </section>
+    <template v-slot:two>
+      <h2>What is cmpct.io?</h2>
+    </template>
+  </slide-wrapper>
 </template>
 
 <script>
@@ -42,22 +37,13 @@ export default {
 <i18n>
 {
   "en": {
-    "pageTitle": "cmpct.io | Free Custom URL Shortener for Safer, Shorter Links",
-    "title": "Custom URL Shortener",
-    "subtitle": "Create free shorter and safer links you can share.",
-    "message": "Paste your link into the box below to get started."
+    "pageTitle": "cmpct.io | Free Custom URL Shortener for Safer, Shorter Links"
   },
   "fr": {
-    "pageTitle": "cmpct.io | Raccourcisseur d'URL personnalisé gratuit pour des liens plus sûrs et plus courts",
-    "title": "Commencer",
-    "subtitle": "Créez gratuitement des liens plus courts et plus sûrs que vous pouvez partager.",
-    "message": "Collez votre lien dans la case ci-dessous pour commencer."
+    "pageTitle": "cmpct.io | Raccourcisseur d'URL personnalisé gratuit pour des liens plus sûrs et plus courts"
   },
   "es": {
-    "pageTitle": "cmpct.io | Acortador de URL personalizado gratuito para enlaces más seguros y cortos",
-    "title": "Empezar",
-    "subtitle": "Cree enlaces gratuitos más cortos y seguros que pueda compartir.",
-    "message": "Pegue su enlace en el cuadro a continuación para comenzar."
+    "pageTitle": "cmpct.io | Acortador de URL personalizado gratuito para enlaces más seguros y cortos"
   }
 }
 </i18n>

--- a/services/debounce.js
+++ b/services/debounce.js
@@ -1,0 +1,11 @@
+module.exports = function debounce (fn, delay) {
+  let timeoutID = null
+  return function () {
+    clearTimeout(timeoutID)
+    const args = arguments
+    const that = this
+    timeoutID = setTimeout(function () {
+      fn.apply(that, args)
+    }, delay)
+  }
+}

--- a/styles/animations.scss
+++ b/styles/animations.scss
@@ -9,6 +9,17 @@ page-enter-active,
   transform-origin: 50% 50%;
 }
 
+.slide-fade-enter-active {
+  transition: all 0.5s ease;
+}
+.slide-fade-leave-active {
+  transition: all 0.8s cubic-bezier(1, 0.5, 0.8, 1);
+}
+.slide-fade-enter, .slide-fade-leave-to
+{
+  opacity: 0;
+}
+
 @keyframes a-translocate_1 {
   0% {
     background-color: #FF0000;

--- a/styles/helpers.scss
+++ b/styles/helpers.scss
@@ -173,6 +173,7 @@ button, .square-button {
   transition: all 0.2s ease-in-out;
   cursor: pointer;
   border: 1px solid white;
+  margin: 0 5px;
 
   .light & {
     border: 1px solid black;


### PR DESCRIPTION
The biggest way cmpct.io can improve its SEO rankings is to add some content to the homepage, at present due to the full screen generator on the homepage; there is very little content, which is undoubtable marking us down in that area.

I am investigating two UX spikes to find the best solution. I want to add content to the homepage without changing too much, or breaking the current user experience.

Spike 1: Involves using a "slide" like mechanism - as deployed on my personal website: https://www.tommcclean.me
Spike 2: Involves simply making it possible to scroll down the page to reach other content.

I don't personally think Spike 1 (this PR) is the best UX for this page, but I wanted to play with it to see.