### PR TITLE
Spike 2: Mechanisms to add content to the Homepage

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,9 +3,7 @@
     <navigator />
     <background />
 
-    <container>
-      <nuxt />
-    </container>
+    <nuxt />
 
     <snackbar />
     <metadata />

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,11 +1,13 @@
 <template>
-  <div :class="uiMode">
-    <not-found
-      v-if="error.statusCode === 404" />
+  <container>
+    <div :class="uiMode">
+      <not-found
+        v-if="error.statusCode === 404" />
 
-    <server-error
-      v-else />
-  </div>
+      <server-error
+        v-else />
+    </div>
+  </container>
 </template>
 
 <script>

--- a/pages/_id.vue
+++ b/pages/_id.vue
@@ -1,15 +1,17 @@
 <template>
-  <section>
-    <links-group />
-    <comments-viewer />
-    <reports-viewer />
-    <image-viewer />
+  <container>
+    <section>
+      <links-group />
+      <comments-viewer />
+      <reports-viewer />
+      <image-viewer />
 
-    <tabs>
-      <comments-tab />
-      <reports-tab />
-    </tabs>
-  </section>
+      <tabs>
+        <comments-tab />
+        <reports-tab />
+      </tabs>
+    </section>
+  </container>
 </template>
 
 <script>

--- a/pages/help.vue
+++ b/pages/help.vue
@@ -1,14 +1,16 @@
 <template>
-  <section class="c-help u-noScroll">
-    <h1
-      v-text="$t('pageTitle')"
-      class="mb-l" />
+  <container>
+    <section class="c-help u-noScroll">
+      <h1
+        v-text="$t('pageTitle')"
+        class="mb-l" />
 
-    <what />
-    <privacy />
-    <price />
-    <safety />
-  </section>
+      <what />
+      <privacy />
+      <price />
+      <safety />
+    </section>
+  </container>
 </template>
 
 <script>

--- a/pages/history.vue
+++ b/pages/history.vue
@@ -1,24 +1,26 @@
 <template>
-  <section class="c-history">
-    <div class="c-history-content">
-      <h1
-        v-text="$t('history')" />
-      <p
-        v-text="$t('description')"
-        class="mb-l" />
+  <container>
+    <section class="c-history">
+      <div class="c-history-content">
+        <h1
+          v-text="$t('history')" />
+        <p
+          v-text="$t('description')"
+          class="mb-l" />
 
-      <div class="c-history-items u-noScroll">
-        <history-item
-          v-for="(item, index) in items"
-          :key="index"
-          v-bind="item" />
+        <div class="c-history-items u-noScroll">
+          <history-item
+            v-for="(item, index) in items"
+            :key="index"
+            v-bind="item" />
+        </div>
       </div>
-    </div>
 
-    <nuxt-link to="/">
-      <circle-button icon="times" />
-    </nuxt-link>
-  </section>
+      <nuxt-link to="/">
+        <circle-button icon="times" />
+      </nuxt-link>
+    </section>
+  </container>
 </template>
 
 <script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,18 +1,20 @@
 <template>
-  <section>
-    <h1
-      v-text="$t('title')" />
-    <p
-      v-text="$t('subtitle')"
-      class="mb" />
-    <p
-      v-text="$t('message')"
-      class="mb-l" />
+  <container>
+    <section>
+      <h1
+        v-text="$t('title')" />
+      <p
+        v-text="$t('subtitle')"
+        class="mb" />
+      <p
+        v-text="$t('message')"
+        class="mb-l" />
 
-    <generator />
-    <group-wrapper />
-    <history-trigger />
-  </section>
+      <generator />
+      <group-wrapper />
+      <history-trigger />
+    </section>
+  </container>
 </template>
 
 <script>


### PR DESCRIPTION
The biggest way cmpct.io can improve its SEO rankings is to add some content to the homepage, at present due to the full screen generator on the homepage; there is very little content, which is undoubtable marking us down in that area.

I am investigating two UX spikes to find the best solution. I want to add content to the homepage without changing too much, or breaking the current user experience.

Spike 1: Involves using a "slide" like mechanism - as deployed on my personal website: https://www.tommcclean.me
Spike 2: Involves simply making it possible to scroll down the page to reach other content.

Personally I think Spike 2 is the best choice in this case.